### PR TITLE
Enable future-dated posts so new blog post appears

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,6 +40,8 @@ theme: minima
 plugins:
   - jekyll-feed
 
+future: true
+
 # Exclude from processing.
 # The following items will not be processed, by default.
 # Any item listed under the `exclude:` key here will be automatically added to


### PR DESCRIPTION
## Summary
- Adds `future: true` to `_config.yml` so Jekyll publishes the 2026-04-13 blog post
- Jekyll excludes future-dated posts by default, which was preventing the "Correctness-Gated Multi-Agent Workflow" post from appearing on the blog page

## Test plan
- [ ] Verify the blog post appears at https://brando90.github.io/brandomiranda/blog.html after merge and GitHub Pages rebuild

https://claude.ai/code/session_01QH66WufFuF6Zi7N8LFDTgM