### PR TITLE
Draft: two new posts — em-dash defense + overfitting vs interpolation

### DIFF
--- a/_drafts/2026-05-04-em-dash-not-an-ai-fingerprint.md
+++ b/_drafts/2026-05-04-em-dash-not-an-ai-fingerprint.md
@@ -1,0 +1,44 @@
+---
+layout: post
+title: "The Em Dash Is Not an AI Fingerprint"
+date: 2026-05-04
+---
+
+<p style="text-align: right;"><em>Brando Miranda — May 2026 · 2 minute read</em></p>
+
+**TL;DR.** I have been using em dashes for years, long before generative AI existed, because William Zinsser told me to in *On Writing Well*. Treating the em dash as a fingerprint of AI writing is a category error: it is a fingerprint of people who learned to write from books that recommend the em dash. Stop punishing the punctuation; punish the prose.
+
+---
+
+There is a small, ambient annoyance I have been carrying for the past year, and I want to put it down.
+
+People keep telling me that my writing "sounds like AI" because I use em dashes. The accusation is usually delivered as a compliment-shaped jab — "great post, but you should maybe dial back the em dashes, it makes it look generated." I understand the suspicion. Long-form models do over-use the em dash, and pattern-matching on punctuation is a cheap heuristic for spotting low-effort text.
+
+The problem is that the heuristic is wrong, and I am Exhibit A.
+
+I bought *On Writing Well* by William Zinsser years before GPT-3, before ChatGPT, before "ChatGPT-style writing" was a phrase anyone said out loud. There is a chapter called "Bits & Pieces," and inside it Zinsser writes:
+
+> "Somehow this invaluable tool is widely regarded as not quite proper — a bumpkin at the genteel dinner table of good English. But it has full membership and will get you out of many tight corners."
+
+That paragraph has been living rent-free in my head since I was an undergrad. The em dash is not a tic. It is a deliberate move with two specific uses, both of which Zinsser lays out — one is to amplify or justify a thought from the first half of a sentence in the second half, and the other is to set off a parenthetical aside without breaking the rhythm of the sentence. I use it because it works.
+
+Calling that an AI fingerprint is like calling clean indentation a Copilot fingerprint. The tool we both happen to use was a tool before either of us got here.
+
+A practical request: when you see writing you suspect of being AI-generated, do not look at the punctuation. Look at the *thinking*. Is there a claim in the post that the author committed to? Is there a counter-argument they actually wrestled with? Is there a sentence that could only have been written by someone with skin in the game? Those are the fingerprints worth checking.
+
+In the meantime, I am keeping my em dashes. Zinsser told me to, the corner I am writing my way out of is real, and the bumpkin has full membership.
+
+---
+
+*If you'd like to cite this post:*
+
+```bibtex
+@misc{miranda2026emdash,
+  author = {Miranda, Brando},
+  title  = {The Em Dash Is Not an AI Fingerprint},
+  year   = {2026},
+  month  = {May},
+  howpublished = {\url{https://brando90.github.io/brandomiranda/}},
+  note   = {Blog post draft}
+}
+```

--- a/_drafts/2026-05-04-overfitting-is-not-interpolation.md
+++ b/_drafts/2026-05-04-overfitting-is-not-interpolation.md
@@ -1,0 +1,64 @@
+---
+layout: post
+title: "Overfitting Is Not Interpolation: Stop Confusing the Two"
+date: 2026-05-04
+---
+
+<p style="text-align: right;"><em>Brando Miranda — May 2026 · 4 minute read</em></p>
+
+**TL;DR.** Fitting your training set is not overfitting. That's *interpolation*. Overfitting is a *generalization* phenomenon: as you keep training, the gap between train loss and test loss grows, or the test loss itself starts going up. Modern deep learning, including LLMs at four to five epochs, routinely shows the opposite: zero training loss while test loss continues to drop. Calling that overfitting tells me the speaker is using a 1990s mental model on 2020s evidence.
+
+---
+
+This is a pet peeve that has been festering for years and I want it on the record.
+
+People say "the model is overfitting" when what they actually mean is "the model has fit the training set." Those are different statements, and conflating them is one of the most persistent misconceptions in applied machine learning, including from people who should know better.
+
+## Definitions, sharpened
+
+- **Interpolation.** The model achieves zero (or near-zero) training error. It has *fit* the data. This is a statement about the training set alone.
+- **Overfitting.** A *generalization* failure. The model's behavior on held-out data is worse than it should be — typically because the train–test gap is large or growing as training continues. This is a statement about the relationship between training and test performance, not about either one in isolation.
+
+You can interpolate without overfitting. You can also overfit without interpolating, if your model is just badly regularized at low training loss. The two concepts are not coupled. They are not even the same kind of object: one is a single-distribution claim, the other is a two-distribution claim.
+
+## What modern deep learning actually does
+
+The reason this matters is that the classical bias–variance picture — where pushing training error to zero must hurt test error — is empirically false in the regimes deep learning operates in. Since roughly 2017, paper after paper has shown that you can drive train loss to zero and *still* see test loss continue to fall. Some references to anchor this:
+
+- **Belkin et al., "Reconciling modern machine learning practice and the bias–variance trade-off," PNAS 2019.** ([paper](https://www.pnas.org/doi/10.1073/pnas.1903070116)) The "double descent" curve: test error goes down, up, then down *again* past the interpolation threshold.
+- **Nakkiran et al., "Deep Double Descent: Where Bigger Models and More Data Hurt," ICLR 2020.** ([paper](https://arxiv.org/abs/1912.02292)) Shows the same pattern across model size and training time, including the phenomenon of *epoch-wise* double descent.
+- **Zhang et al., "Understanding deep learning requires rethinking generalization," ICLR 2017.** ([paper](https://arxiv.org/abs/1611.03530)) Networks that interpolate random labels still generalize on real labels — train loss alone tells you nothing.
+- **Power et al., "Grokking: Generalization beyond Overfitting on Small Algorithmic Datasets," 2022.** ([paper](https://arxiv.org/abs/2201.02177)) Train loss goes to zero, test loss is bad for a long time, and then suddenly snaps to perfect generalization. Train-zero is not the end of the story.
+
+> TODO (refs to verify before publish): For LLMs specifically, the four-to-five-epoch claim — Muennighoff et al. *Scaling Data-Constrained Language Models* (2023) shows multi-epoch training is roughly as good as fresh data up to ~4 epochs of repetition; needs a citation pass to confirm exact phrasing for "test perplexity continues to drop past the train-loss-floor." If we cannot find a clean citation, drop to a softer claim.
+
+## What people get wrong, in practice
+
+The mistake usually shows up as one of three errors:
+
+1. **"Train loss is too low, you're overfitting."** No. Train loss being low says nothing about generalization on its own. Show me the test curve.
+2. **"You ran four epochs, you're overfitting."** Number of epochs is not a definition of overfitting. The definition of overfitting is a property of the test curve, not the train curve.
+3. **"The model has memorized the data, so it's overfitting."** Memorization is not equivalent to overfitting. Modern models memorize *and* generalize. The relationship is more subtle than the textbook says.
+
+The fix is small and free: when you mean "the model has fit the training set," say *interpolation* or *fit*. Reserve *overfitting* for the actual phenomenon of degraded generalization. The vocabulary is already there.
+
+## Why I care
+
+I care because every time someone writes "the model is overfitting" when they mean "train loss hit zero," they are quietly importing the conclusion that we should stop training. Sometimes that is right. Often it is wrong. In the LLM era, "stop training when train loss is low" would have left enormous headroom on the table. The vocabulary is a load-bearing piece of judgment, and using it wrong leads to wrong calls.
+
+So: interpolation is when you fit the data. Overfitting is when generalization breaks. They are not the same. Please stop using them as if they are.
+
+---
+
+*If you'd like to cite this post:*
+
+```bibtex
+@misc{miranda2026overfitting,
+  author = {Miranda, Brando},
+  title  = {Overfitting Is Not Interpolation: Stop Confusing the Two},
+  year   = {2026},
+  month  = {May},
+  howpublished = {\url{https://brando90.github.io/brandomiranda/}},
+  note   = {Blog post draft}
+}
+```


### PR DESCRIPTION
## Summary

Two short blog post drafts in `_drafts/` (not rendered by Jekyll until moved to `_posts/`). **Intentionally not for merge** — drafts only, awaiting Brando's review and edits.

### 1. `_drafts/2026-05-04-em-dash-not-an-ai-fingerprint.md`
Short, opinionated defense of the em-dash as a stylistic choice that predates generative AI. Cites William Zinsser's *On Writing Well* "Bits & Pieces" chapter ("a bumpkin at the genteel dinner table of good English"). ~2 minute read.

Tracking issue: see linked issue.

### 2. `_drafts/2026-05-04-overfitting-is-not-interpolation.md`
Direct technical correction. Overfitting is a **generalization-gap** phenomenon, not "the train loss hit zero." References:
- Belkin et al. ([PNAS 2019, double descent](https://www.pnas.org/doi/10.1073/pnas.1903070116))
- Nakkiran et al. ([ICLR 2020, deep double descent](https://arxiv.org/abs/1912.02292))
- Zhang et al. ([ICLR 2017, rethinking generalization](https://arxiv.org/abs/1611.03530))
- Power et al. ([grokking, 2022](https://arxiv.org/abs/2201.02177))

Contains an in-text TODO marker for the LLM multi-epoch claim (test perplexity continues to drop past zero train loss at 4–5 epochs) — needs a verification pass on Muennighoff et al. *Scaling Data-Constrained Language Models* (2023) before publish, or we should soften the claim.

Tracking issue: see linked issue.

## Test plan
- [ ] Brando reads both drafts for tone and accuracy.
- [ ] Verify the LLM-epoch citation in the overfitting post or soften the claim.
- [ ] Confirm the book title — Brando said "writing well or something" in DM; this draft uses *On Writing Well* by Zinsser, which matches the description and the em-dash quote in the "Bits & Pieces" chapter.
- [ ] When approved, move both files from `_drafts/` to `_posts/` and adjust the date if needed.

**Do not merge** until Brando signs off.

https://claude.ai/code/session_01VN9DbT2toEV6zDwgCfg8Qg

---
_Generated by [Claude Code](https://claude.ai/code/session_01VN9DbT2toEV6zDwgCfg8Qg)_