### PR TITLE
Add reading-time estimates to all posts + draft tweets for each

### DIFF
--- a/_drafts/blog-post-tweets.md
+++ b/_drafts/blog-post-tweets.md
@@ -1,0 +1,100 @@
+# Tweet drafts for blog posts
+
+Copy-paste-ready tweets for advertising each post. Each one is short, leads with a hook, ends with the post URL, and (where it fits) invites feedback. Twitter/X counts URLs as 23 characters regardless of length, so the body can be longer than it looks. Aim is comfortably under the 280-char limit with room to add hashtags or `@`-mentions if you want.
+
+Feel free to tweak voice, swap a quote for the hook, or add hashtags like `#AI`, `#Lean4`, `#MachineLearning`, `#Jazz`, `#GradSchool` depending on the audience you want to reach.
+
+---
+
+## 2019 — Building Synergetic Teams for Research and Startups
+
+Great teams aren't lucky — they're loops. When leaders genuinely work to fulfill what each member wants, members reciprocate with their best. Wrote up the principle (and why it scales). Feedback welcome:
+https://brando90.github.io/brandomiranda/2019/10/28/synergetic-team.html
+
+---
+
+## 2019 — Jazz Improvisation
+
+Jazz and dance improvisation are the same skill in different clothes: internalize the structure deeply enough that you can leave it on purpose. A short note from 2019:
+https://brando90.github.io/brandomiranda/2019/10/31/jazz-improvisation.html
+
+---
+
+## 2019 — Uniform Stability in Machine Learning Theory
+
+You don't need VC dimension or Rademacher complexity to prove generalization. Uniform stability — algorithms whose output barely changes when you swap one training point — gets you there directly. Walked through the proofs:
+https://brando90.github.io/brandomiranda/2019/10/31/uniform-stability.html
+
+---
+
+## 2020 — Mindfulness as a Cure for Anxiety
+
+Anxiety behaves like a habit loop: cue → behavior → reward. Mindfulness doesn't fight the loop — it turns curiosity onto the reward, which weakens the loop and the anxiety with it. Neuroscience-backed:
+https://brando90.github.io/brandomiranda/2020/10/18/mindfulness-as-a-cure-for-anxiety.html
+
+---
+
+## 2020 — How to Write a Statement of Purpose for Graduate School
+
+A strong grad-school SOP isn't a list of accomplishments — it's a specific story that makes your trajectory feel inevitable. Concrete experience, clear fit, real narrative. Feedback welcome:
+https://brando90.github.io/brandomiranda/2020/11/14/SOP.html
+
+---
+
+## 2020 — Thriving in the Research Community
+
+How to thrive in research: pick problems you genuinely care about, write papers to share ideas (not impress), and when you're stuck — change the question instead of grinding harder on the wrong one.
+https://brando90.github.io/brandomiranda/2020/12/20/thriving-in-the-research-community.html
+
+---
+
+## 2026 — Correctness-Gated Multi-Agent Workflow
+
+The right question with AI coding agents isn't "which model is best?" — it's "what process makes model mistakes cheap to detect?" I built and open-sourced a correctness-gated multi-agent workflow for research. Feedback welcome:
+https://brando90.github.io/brandomiranda/2026/04/13/correctness-gated-multi-agent-workflow.html
+
+---
+
+## 2026 — Two TLDRs Are Better Than One
+
+A weird tiny prompt-design fix: open with TLDR-start, close with TLDR-end, and tell the model to ignore the first when writing the second. Why position on the page changes quality, not just visibility:
+https://brando90.github.io/brandomiranda/2026/04/16/dual-tldr-top-and-end.html
+
+---
+
+## 2026 — Asking the Right Question: Formal Methods as Scalable Oversight
+
+In the era of AI agents, formal methods are finally within practical reach for scalable oversight. Let the verifier check the answer; let the human check the question. What we may not be able to outsource is knowing what we want:
+https://brando90.github.io/brandomiranda/2026/04/22/formal-methods-scalable-oversight.html
+
+---
+
+## 2026 — Embrace AI or Be Left Behind
+
+The real risk of ignoring AI isn't that machines replace you — it's that people who use them will. AI is a force of nature. I'd rather merge with the wave than fight it. Why I feel morally obliged to recommend it:
+https://brando90.github.io/brandomiranda/2026/04/27/embrace-ai-or-be-left-behind.html
+
+---
+
+## 2026 — Metallica Goes Jazz
+
+In 2010 I hand-arranged Metallica's *The Day That Never Comes* for my high school orchestra. 16 years later I fed that score into Suno and asked it to recast the piece in the voices of Charlie Parker, Chet Baker, Stan Getz... Take 1 inside:
+https://brando90.github.io/brandomiranda/2026/05/07/metallica-goes-jazz.html
+
+---
+
+## Optional alternates
+
+A few alternative phrasings if you want a different angle on specific posts.
+
+**Embrace AI (alternate, more personal):**
+I have no choice. Not because someone's forcing me — because pretending these tools don't change everything is self-defeating. Why I think AI is a force of nature, and why merging with it is the only rational response:
+https://brando90.github.io/brandomiranda/2026/04/27/embrace-ai-or-be-left-behind.html
+
+**Metallica Goes Jazz (alternate, hook-on-AI):**
+The gap between *I wonder what this would sound like* and *here is what it sounds like* has collapsed. So I revisited a Metallica arrangement I wrote in high school in 2010 — and asked Suno to play it like Bird, Chet, Cannonball, Getz:
+https://brando90.github.io/brandomiranda/2026/05/07/metallica-goes-jazz.html
+
+**Correctness-gated workflow (alternate, builder framing):**
+Spent a year asking: how do you use coding agents for serious work without quietly degrading quality? Answer: stop chasing the best model, start designing the process that makes mistakes cheap to catch. Open-sourced the setup:
+https://brando90.github.io/brandomiranda/2026/04/13/correctness-gated-multi-agent-workflow.html

--- a/_posts/2019-10-28-synergetic-team.md
+++ b/_posts/2019-10-28-synergetic-team.md
@@ -4,6 +4,8 @@ title: "Building Synergetic Teams for Research and Startups"
 date: 2019-10-28 14:23 -0500
 ---
 
+*~3 min read*
+
 **TL;DR.** Great teams run on positive reward loops. When a leader genuinely works to fulfill each member's aspirations, members reciprocate with their best effort — and offering the best opportunities is what attracts the best people in the first place.
 
 First and foremost, allow me to elucidate the concept of synergy, an indispensable term which I discovered through this educational journey:

--- a/_posts/2019-10-31-jazz-improvisation.md
+++ b/_posts/2019-10-31-jazz-improvisation.md
@@ -4,6 +4,8 @@ title: "Jazz Improvisation"
 date: 2019-10-31 21:25 -0500
 ---
 
+*~1 min read*
+
 **TL;DR.** Jazz and dance improvisation are the same skill wearing different clothes: internalize structure deeply enough that you can leave it on purpose without falling apart.
 
 I originally wrote [this](https://qr.ae/TUK1i7) answer on Quora on

--- a/_posts/2019-10-31-uniform-stability.md
+++ b/_posts/2019-10-31-uniform-stability.md
@@ -4,6 +4,8 @@ title: "Uniform Stability in Machine Learning Theory"
 date: 2019-10-31 21:09 -0500
 ---
 
+*~1 min read*
+
 **TL;DR.** Uniform stability — an algorithm whose output barely changes when you swap one training point — directly implies generalization, without needing VC dimension or Rademacher complexity. This writeup walks through the proofs end to end.
 
 - When I took 9.520 at MIT with the wonderful professors

--- a/_posts/2020-10-18-mindfulness-as-a-cure-for-anxiety.md
+++ b/_posts/2020-10-18-mindfulness-as-a-cure-for-anxiety.md
@@ -4,6 +4,8 @@ title: "Mindfulness as a Cure for Anxiety"
 date: 2020-10-18 21:09 -0500
 ---
 
+*~3 min read*
+
 **TL;DR.** Anxiety behaves like a habit loop — cue, behavior, reward. Mindfulness works by turning curiosity onto the reward itself, which weakens the loop and the anxiety with it. Neuroscience-backed and directly applicable to everyday habits.
 
 

--- a/_posts/2020-11-14-SOP.md
+++ b/_posts/2020-11-14-SOP.md
@@ -4,6 +4,8 @@ title: "How to Write a Statement of Purpose for Graduate School"
 date: 2020-11-14 20:19 -0500
 ---
 
+*~4 min read*
+
 **TL;DR.** A strong graduate-school SOP is a specific story, not a list of accomplishments: concrete research experience, a clear fit to the program and advisor, and a narrative that makes your trajectory feel inevitable.
 
 

--- a/_posts/2020-12-20-thriving-in-the-research-community.md
+++ b/_posts/2020-12-20-thriving-in-the-research-community.md
@@ -4,6 +4,8 @@ title: "Thriving in the Research Community"
 date: 2020-12-20 22:12 -0500
 ---
 
+*~3 min read*
+
 **TL;DR.** How to thrive as a researcher: pick problems you genuinely care about, write papers to share ideas rather than to impress, and when you're stuck, change the question instead of grinding harder on the wrong one.
 
 

--- a/_posts/2026-04-13-correctness-gated-multi-agent-workflow.md
+++ b/_posts/2026-04-13-correctness-gated-multi-agent-workflow.md
@@ -4,6 +4,8 @@ title: "What I Learned Building a Correctness-Gated Multi-Agent Workflow for Res
 date: 2026-04-13
 ---
 
+*~7 min read*
+
 *Brando Miranda — April 2026*
 
 **TL;DR.** The right question with AI coding agents isn't "which model is best?" — it's "what process makes model mistakes cheap to detect?" I built a modular, correctness-gated multi-agent workflow (cross-agent review, structural QA, formal verification via Lean) and published the setup as an open-source documentation architecture called [agents-config](https://github.com/brando90/agents-config).

--- a/_posts/2026-04-16-dual-tldr-top-and-end.md
+++ b/_posts/2026-04-16-dual-tldr-top-and-end.md
@@ -4,6 +4,8 @@ title: "Two TLDRs Are Better Than One: A Small Prompt-Design Fix That Matters Mo
 date: 2026-04-16
 ---
 
+*~5 min read*
+
 *Brando Miranda — April 2026*
 
 A short post about a tiny change I made to my [agents-config](https://github.com/brando90/agents-config) rules — adding a second TLDR to the top of every agent response — and why the tiny change is actually a lesson about how position on the page interacts with chain-of-thought.

--- a/_posts/2026-04-22-formal-methods-scalable-oversight.md
+++ b/_posts/2026-04-22-formal-methods-scalable-oversight.md
@@ -4,6 +4,8 @@ title: "Asking the Right Question: Formal Methods as Scalable Oversight"
 date: 2026-04-22
 ---
 
+*~6 min read*
+
 *Brando Miranda — April 2026*
 
 **TL;DR.** In the era of AI agents, formal methods like Lean are finally within practical reach for scalable oversight of complex arguments. Let the verifier check the answer; let the human check the question. Deciding what to ask — knowing what we actually want — is the part we may not be able to outsource.

--- a/_posts/2026-04-27-embrace-ai-or-be-left-behind.md
+++ b/_posts/2026-04-27-embrace-ai-or-be-left-behind.md
@@ -4,6 +4,8 @@ title: "Embrace AI or Be Left Behind — By People, Not Machines"
 date: 2026-04-27
 ---
 
+*~6 min read*
+
 *Brando Miranda — April 2026*
 
 **TL;DR.** The real risk of ignoring AI isn't that machines replace you — it's that people who use them will. AI is a force of nature: trained on the world's data, improving relentlessly. Adapting isn't optional enthusiasm; it's survival. I'd rather merge with the wave than fight it.

--- a/_posts/2026-05-07-metallica-goes-jazz.md
+++ b/_posts/2026-05-07-metallica-goes-jazz.md
@@ -4,6 +4,8 @@ title: "Metallica Goes Jazz: A 2010 High School Arrangement, Reanimated by AI"
 date: 2026-05-07
 ---
 
+*~6 min read*
+
 *Brando Miranda — May 2026*
 
 **TL;DR.** In 2010, as a high schooler at Greengates, I arranged Metallica's *The Day That Never Comes* by hand for the school orchestra. Sixteen years later, I fed that same arrangement into [Suno](https://suno.com/) and asked it to recast the piece in the styles of Chet Baker, Cannonball Adderley, Charlie Parker, Joe Henderson, Stan Getz, and Sonny Rollins. [Here is the first take.](https://suno.com/s/1RTl4ch6L6LlbIFP) The point isn't novelty. The point is that AI lets you keep playing with old work in ways your past self never had the chops — or the time, or the ensemble — to attempt.


### PR DESCRIPTION
## Summary
- Adds a `*~N min read*` line at the very top of every post in `_posts/` (after the frontmatter, before the byline/TLDR), computed at ~220 wpm and rounded up. Reading times range from ~1 min (uniform-stability, jazz-improvisation) to ~7 min (correctness-gated workflow). Done as static text per post since the site uses the `minima` gem theme — overriding the layout was a bigger change than the request warranted.
- Adds `_drafts/blog-post-tweets.md` with copy-paste-ready tweet drafts for advertising each post. One short tweet per post, each leading with a hook and ending with the post URL, sized to fit under the 280-char limit. A few alternate phrasings included for the AI/jazz posts. Living in `_drafts/` so Jekyll won't render it.

## Test plan
- [ ] Visit the rendered site and confirm the reading-time line appears at the top of each post in the right spot.
- [ ] Spot-check at least one tweet for character length on Twitter/X compose (URLs count as 23 chars regardless of length).
- [ ] Decide if any time estimate feels off — easy to bump up/down.


---
_Generated by [Claude Code](https://claude.ai/code/session_019M4RhKFVV9QpQGzm3FzBvR)_