### PR TITLE
Experiment 02: PicoML → toy ITP + companion blog draft

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "experiments/02_picoml_to_toy_itp/cs421"]
+	path = experiments/02_picoml_to_toy_itp/cs421
+	url = https://github.com/brando90/cs421.git

--- a/_drafts/2026-05-12-picoml-to-toy-itp.md
+++ b/_drafts/2026-05-12-picoml-to-toy-itp.md
@@ -1,0 +1,224 @@
+---
+layout: post
+title: "From PicoML to a Toy ITP: Demystifying Lean by Writing the Type Checker Yourself"
+date: 2026-05-12
+---
+
+*Brando Miranda — May 2026*
+
+**TL;DR.** The kernel of an interactive theorem prover like Lean 4 is, at its
+heart, a type checker. If you've ever written a Hindley–Milner inferencer for
+a small ML — the kind you ship as part of CS421 at UIUC — you have already
+written ~70% of the conceptual machinery of an ITP. The remaining 30% is
+*more* type theory, not magic: bidirectional checking, dependent function
+types, universes, and a small tactic layer that turns the checker into an
+interactive tool. To make this concrete, I started [a public
+experiment](https://github.com/brando90/brandomiranda/tree/main/experiments/02_picoml_to_toy_itp)
+that walks the path *PicoML → System F → λΠ → toy ITP*, starting from the
+PicoML I wrote in CS421 in undergrad. I'm also building this in the open as
+a follow-up to my earlier post on [why Lean beats SMT for ML-based theorem
+proving]({{ site.baseurl }}2026/05/12/lean-vs-atp.html).
+
+## Why I think Lean feels like magic — and isn't
+
+When people first open Lean 4, the experience is disorienting. You type a
+goal. You type `intro h`. Suddenly the goal changes. You type `apply foo`.
+The goal splits. Eventually `rfl` closes it and the file is green. It feels
+like a logic engine is doing something deep on your behalf.
+
+The framing I want to push back on is: *Lean is not a search engine pretending
+to prove your theorem.* Lean is a **type checker** with a tactic-shaped UI on
+top. The type checker is small — the Lean 4 kernel is a few thousand lines —
+and it is doing exactly one thing: deciding whether a term has a given type.
+The tactic layer is a sugared way to build that term incrementally.
+
+> A proof of `P` is a term of type `P`. Closing a goal is producing a term.
+> Lean checks types. That's it.
+
+That sounds reductive, but it's correct, and once you build a kernel like
+this yourself it stops being mysterious. The goal of this post (and the
+experiment) is to take you down that path concretely.
+
+## The path
+
+```
+STLC  →  Hindley–Milner  →  System F  →  λΠ  →  MLTT-ish core  →  tactics
+ ▲           ▲                                                       ▲
+ │           │                                                       │
+ CS421       my single-file PicoML rewrite                           toy ITP
+```
+
+Each arrow is a *type system extension*, not a paradigm shift. The
+substitution / unification / context-manipulation code from the previous
+phase mostly survives; what changes is what the types can express.
+
+- **STLC**: types are `int | bool | t1 -> t2`. No polymorphism.
+- **Hindley–Milner**: add type variables and `Forall (αs, t)` schemes
+  introduced by `let`. This is what PicoML and OCaml/Haskell are.
+- **System F**: types include `∀α. t` everywhere, not just at `let`. You can
+  now type `fun id -> (id 1, id true)` as long as `id` is given a
+  polymorphic type explicitly.
+- **λΠ (dependent function types)**: the type of the result can mention the
+  *value* of the argument. `Π (n : ℕ). Vec ℕ n` is "for every `n`, a vector
+  of length `n`." This is the first system in which `theorem` actually
+  means something.
+- **MLTT core**: add universes (`Type 0 : Type 1 : ...`), Σ-types, inductive
+  types with their eliminators, propositional equality, and you have the
+  conceptual core of Lean, Coq, and Agda.
+- **Tactics**: not a new logic. Tactics are *meta-level* programs that
+  manipulate proof states and emit terms; the kernel re-checks them. You can
+  add `intro`, `apply`, `rewrite`, `induction` in a few hundred lines.
+
+The thing I want to emphasise is that the *kernel never gets much bigger*.
+The interesting growth is in what your `infer` and `unify` functions need to
+handle. Once you've done Hindley–Milner, dependent types are "just" adding
+β-reduction inside unification and being careful about variable capture.
+
+## The starting point: a 150-line HM inferencer
+
+I have my old CS421 PicoML sitting in
+[`brando90/cs421`](https://github.com/brando90/cs421) — the lexer, parser,
+type inferencer and evaluator that Elsa Gunter's course walked us through.
+I've vendored it as a git submodule in the experiment so the reference is
+right there, but I also wrote a from-scratch single-file rewrite — small
+enough to read in one sitting and to extend phase by phase.
+
+The whole inferencer is in
+[`experiments/02_picoml_to_toy_itp/picoml.ml`](https://github.com/brando90/brandomiranda/blob/main/experiments/02_picoml_to_toy_itp/picoml.ml).
+The interesting pieces are:
+
+**Substitution & unification.** A substitution is a map from type variables
+to types. Composition is "apply the first to the rhs of the second, then
+union." Unification is Robinson's algorithm: walk both types in parallel,
+bind variables, occurs-check.
+
+```ocaml
+let rec unify (t1 : ty) (t2 : ty) : subst =
+  match t1, t2 with
+  | TInt, TInt | TBool, TBool       -> SMap.empty
+  | TVar a, t  | t, TVar a          -> bind_var a t
+  | TFun (a1, b1), TFun (a2, b2)    ->
+      let s1 = unify a1 a2 in
+      let s2 = unify (apply_ty s1 b1) (apply_ty s1 b2) in
+      compose s2 s1
+  | _ -> raise (Type_error "type mismatch")
+```
+
+**Generalisation & instantiation.** This is the whole secret of `let`-polymorphism:
+at a `let`, close over the type variables that aren't pinned by the
+environment, producing a `∀αs. t` *scheme*. At a use site, instantiate fresh
+variables for the `αs`. That is why `let id = fun x -> x in (id 1, id true)`
+type-checks but `(fun id -> (id 1, id true)) (fun x -> x)` does not.
+
+```ocaml
+let generalize env t =
+  let vs = SSet.diff (ftv_ty t) (ftv_env env) in
+  Forall (SSet.elements vs, t)
+
+let instantiate (Forall (vs, t)) =
+  let s = List.fold_left (fun m v -> SMap.add v (fresh ()) m) SMap.empty vs in
+  apply_ty s t
+```
+
+**Algorithm W.** Inference is one function per expression form. The two
+returns are "what I learned about types so far" (a substitution) and "what
+type this expression has." Both are needed: the substitution flows along the
+spine of the term and gets composed; the type bubbles up.
+
+You can run it locally:
+
+```sh
+git clone https://github.com/brando90/brandomiranda
+cd brandomiranda/experiments/02_picoml_to_toy_itp
+ocaml picoml.ml
+```
+
+Output:
+
+```
+42                                                 : int
+true                                               : bool
+fun x -> x                                         : 'a1 -> 'a1
+let id = fun x -> x in id 3                        : int
+let id = fun x -> x in (id 1, id true) ~ poly      : int
+if true then 1 else 2                              : int
+fun f -> fun x -> f (f x)                          : ('a4 -> 'a4) -> 'a4 -> 'a4
+```
+
+The Church-numeral-twice example showing `('a -> 'a) -> 'a -> 'a` is the
+moment HM earns its keep: no annotations, fully polymorphic, principal type
+recovered for you.
+
+## What it looks like to climb from HM to dependent types
+
+A few concrete deltas, so the rest of the path isn't hand-waving:
+
+**HM → System F.** Drop principal types. Switch from Algorithm W to
+*bidirectional* checking: every term either *checks* against a known type or
+*synthesises* one, and the two modes are mutually recursive. The win is
+predictability and explicit polymorphism. You add `ΛTλ. e` (big lambda) and
+`e [t]` (type application).
+
+**System F → λΠ.** Function types become `Π (x : A). B[x]` where `B` may
+mention `x`. The big change is that *types now contain terms*, so checking
+"is `A1` equal to `A2`?" can require β-reducing. Unification stops being
+syntactic and becomes "up to conversion." This is where you first feel the
+shape of a real proof assistant.
+
+**λΠ → MLTT core.** Add `Type i` universes so types have types. Add
+inductive types (`Nat`, `List`, `Vec`, `Eq`) with their constructors and
+eliminators. Add Σ-types for existentials. Once `Id A x y` (propositional
+equality) is in the system, `theorem foo : x = y := refl` is just a
+type-checking judgement.
+
+**MLTT → toy ITP.** A *tactic* is a function `ProofState → ProofState ×
+PartialTerm`. `intro h` strips a leading `Π` from the goal and adds `h` to
+the local context. `apply f` unifies the goal with the codomain of `f`'s
+type and produces new goals for each argument. `rfl` succeeds iff the two
+sides of the equality reduce to the same normal form. None of these are
+trusted — they emit terms, and the kernel re-checks them. You can add the
+five tactics that close 90% of beginner Lean exercises in an afternoon.
+
+## Why I'm doing this in public
+
+Two reasons.
+
+**One**, for myself. The fastest way I know to internalise a system is to
+implement it. I have written PicoML before; I have used Lean 4; I have not
+*bridged* the two in my own head with code. This experiment is that bridge.
+
+**Two**, because I think the "Lean is magic" framing is doing damage to the
+ML-for-math conversation. If you believe Lean is a black-box search engine,
+RL-on-Lean looks like a wild reinforcement-learning problem. If you believe
+Lean is a *type checker with a UI*, then "training a model to prove
+theorems" is the much more tractable problem of *training a model to write
+well-typed terms*, which is just code generation with a strong oracle. This
+is the same point I made in the [Lean vs ATP post]({{ site.baseurl }}2026/05/12/lean-vs-atp.html),
+but from the implementation side instead of the expressivity side.
+
+If you have ever stared at a Lean tactic block and wondered what is really
+going on underneath: this is the experiment. The first commit is a
+150-line HM inferencer. The last commit, if I get there, is a proof of
+`n + 0 = n` by tactics, in a system small enough to read end-to-end.
+
+## Where to follow along
+
+- Tracking issue:
+  [brando90/brandomiranda#XX](https://github.com/brando90/brandomiranda/issues)
+  (open as of this post)
+- Experiment directory:
+  [`experiments/02_picoml_to_toy_itp/`](https://github.com/brando90/brandomiranda/tree/main/experiments/02_picoml_to_toy_itp)
+- CS421 reference (vendored submodule):
+  [`brando90/cs421`](https://github.com/brando90/cs421)
+- Companion post on motivation:
+  [Lean vs ATPs]({{ site.baseurl }}2026/05/12/lean-vs-atp.html)
+
+## References
+
+- Pierce, *Types and Programming Languages* — Ch. 22 (HM), Ch. 23 (System F).
+- Pierce (ed.), *Advanced Topics in TPL* — Ch. 2 (bidirectional), Ch. 11 (dependent).
+- Nederpelt & Geuvers, *Type Theory and Formal Proof* — λΠ and beyond.
+- Löh, McBride, Swierstra — *A Tutorial Implementation of a Dependently
+  Typed Lambda Calculus*.
+- Andrej Bauer — *How to Implement Dependent Type Theory* (blog series).
+- Elsa Gunter — CS421 course materials, UIUC.

--- a/_drafts/2026-05-12-picoml-to-toy-itp.md
+++ b/_drafts/2026-05-12-picoml-to-toy-itp.md
@@ -204,8 +204,9 @@ going on underneath: this is the experiment. The first commit is a
 ## Where to follow along
 
 - Tracking issue:
-  [brando90/brandomiranda#XX](https://github.com/brando90/brandomiranda/issues)
-  (open as of this post)
+  [brando90/brandomiranda#51](https://github.com/brando90/brandomiranda/issues/51)
+- PR (Phase 1 + scaffolding):
+  [brando90/brandomiranda#52](https://github.com/brando90/brandomiranda/pull/52)
 - Experiment directory:
   [`experiments/02_picoml_to_toy_itp/`](https://github.com/brando90/brandomiranda/tree/main/experiments/02_picoml_to_toy_itp)
 - CS421 reference (vendored submodule):

--- a/experiments/02_picoml_to_toy_itp/README.md
+++ b/experiments/02_picoml_to_toy_itp/README.md
@@ -1,0 +1,81 @@
+# From PicoML to a Toy ITP
+
+Self-study experiment: build a type checker for a small ML, then keep
+extending the type system until what comes out the other end is a tiny
+interactive theorem prover.
+
+The starting point is **PicoML**, the teaching language used in
+**CS421 (Programming Languages and Compilers)** at UIUC under Elsa Gunter.
+PicoML is an ML-flavoured language with Hindley–Milner inference, sum/product
+types, lists, and pattern matching. It's a clean Goldilocks language: small
+enough to implement in a weekend, rich enough that every interesting
+type-system idea has somewhere to land.
+
+My own CS421 coursework — lectures, MPs, exams, and a working PicoML
+interpreter — is vendored here as a git submodule:
+
+```sh
+git submodule update --init experiments/02_picoml_to_toy_itp/cs421
+```
+
+The PicoML reference implementation from the course sits at
+[`cs421/mp/mp5/`](cs421/mp/mp5) (lexer, parser, type inferencer, evaluator).
+The `picoml.ml` in this directory is a single-file, from-scratch rewrite —
+small enough to read in one sitting — that I'll then keep extending past
+where the course stops.
+
+The endpoint is a **toy ITP** in the spirit of Lean / Coq / Agda — a few
+hundred lines of code whose `check : Env -> Term -> Type -> bool` function is
+literally the proof checker.
+
+## Roadmap
+
+| Phase | Type system                                  | Deliverable                                                              |
+|------:|----------------------------------------------|--------------------------------------------------------------------------|
+| 0     | STLC                                         | `picoml.ml` — STLC subset, sanity test of the substitution + unify code  |
+| 1     | Hindley–Milner (`let`-polymorphism)          | `picoml.ml` (current draft) — Algorithm W, smoke tests                   |
+| 2     | HM + ADTs, lists, pattern matching, records  | Full PicoML; lex + parse so you can type-check source files              |
+| 3     | System F (rank-N, explicit `∀`)              | Bidirectional checker; lose principal types, gain expressiveness         |
+| 4     | λΠ (dependent function types, no universes)  | First "proofs as programs" — `Id` type, `J`, `refl`                      |
+| 5     | MLTT-ish core (universes, Σ, W, inductives)  | Kernel of the toy ITP                                                    |
+| 6     | Tactic layer (`intro`, `apply`, `rewrite`)   | Toy ITP — write a proof of `n + 0 = n` by tactics                        |
+
+## Why pair PicoML with a toy ITP?
+
+- **The kernel of an ITP is a type checker.** Phases 0–2 build that muscle in a
+  setting where the rules are well-understood and there's a reference
+  implementation (CS421's solutions) to diff against.
+- **The jump from HM to dependent types is the interesting bit** — that's
+  where unification has to deal with terms, conversion enters the picture,
+  and Algorithm W stops being enough. Phases 3–5 are where the learning
+  happens.
+- **A tactic layer on top of a checker is small.** Tactics are partial
+  functions on proof states; the kernel does the validation. So once
+  the checker is solid, the ITP is mostly UI.
+
+## References
+
+- **CS421 PicoML** — Elsa Gunter, UIUC. Course materials, MPs.
+- **Pierce, *Types and Programming Languages*** — Ch. 22 (HM), Ch. 23 (System F).
+- **Pierce (ed.), *Advanced Topics in TPL*** — Ch. 2 (bidirectional), Ch. 11 (dependent).
+- **Nederpelt & Geuvers, *Type Theory and Formal Proof*** — λΠ and beyond.
+- **Andrej Bauer's "How to implement dependent type theory"** blog series.
+- **"A tutorial implementation of a dependently typed lambda calculus"** —
+  Löh, McBride, Swierstra.
+
+## Running
+
+```sh
+cd experiments/02_picoml_to_toy_itp
+ocaml picoml.ml
+```
+
+Expected output is one line per test expression with its inferred type;
+the polymorphic-identity test should print a type containing `'a` /
+showing `id` was generalised.
+
+## Status
+
+- [x] Phase 1 draft: HM inferencer, ~150 LoC, smoke-tested
+- [ ] Phase 2: lexer/parser + ADTs + lists
+- [ ] Phase 3+: see roadmap

--- a/experiments/02_picoml_to_toy_itp/picoml.ml
+++ b/experiments/02_picoml_to_toy_itp/picoml.ml
@@ -1,0 +1,199 @@
+(* PicoML: a tiny Hindley-Milner type inferencer.
+   Single-file, runnable as: ocaml picoml.ml
+   Starting point for the experiment described in ../README.md and the
+   linked GitHub issue: scale this kernel from HM up to a dependently-typed
+   core, then bolt a tactic layer on top to make a toy ITP. *)
+
+(* --- AST ------------------------------------------------------------ *)
+
+type binop = Add | Sub | Mul | Eq | Lt
+
+type expr =
+  | EInt  of int
+  | EBool of bool
+  | EVar  of string
+  | EFun  of string * expr
+  | EApp  of expr * expr
+  | ELet  of string * expr * expr        (* let x = e1 in e2 — polymorphic *)
+  | EIf   of expr * expr * expr
+  | EBop  of binop * expr * expr
+
+(* --- Types ---------------------------------------------------------- *)
+
+type ty =
+  | TInt
+  | TBool
+  | TVar of string
+  | TFun of ty * ty
+
+type scheme = Forall of string list * ty
+
+module SMap = Map.Make (String)
+module SSet = Set.Make (String)
+
+type subst = ty SMap.t
+type env   = scheme SMap.t
+
+(* --- Substitution & free type variables ----------------------------- *)
+
+let rec apply_ty (s : subst) (t : ty) : ty =
+  match t with
+  | TInt | TBool -> t
+  | TVar a ->
+      (match SMap.find_opt a s with
+       | Some t' -> apply_ty s t'   (* chase through chains *)
+       | None    -> t)
+  | TFun (a, b) -> TFun (apply_ty s a, apply_ty s b)
+
+let apply_scheme (s : subst) (Forall (vs, t)) : scheme =
+  let s' = List.fold_left (fun m v -> SMap.remove v m) s vs in
+  Forall (vs, apply_ty s' t)
+
+let apply_env (s : subst) (e : env) : env =
+  SMap.map (apply_scheme s) e
+
+(* s1 ∘ s2  — apply s1 to the rhs of s2, then union (s1 wins on clash) *)
+let compose (s1 : subst) (s2 : subst) : subst =
+  let s2' = SMap.map (apply_ty s1) s2 in
+  SMap.union (fun _ a _ -> Some a) s1 s2'
+
+let rec ftv_ty = function
+  | TInt | TBool -> SSet.empty
+  | TVar a       -> SSet.singleton a
+  | TFun (a, b)  -> SSet.union (ftv_ty a) (ftv_ty b)
+
+let ftv_scheme (Forall (vs, t)) =
+  SSet.diff (ftv_ty t) (SSet.of_list vs)
+
+let ftv_env (e : env) =
+  SMap.fold (fun _ s acc -> SSet.union (ftv_scheme s) acc) e SSet.empty
+
+(* --- Fresh type variables ------------------------------------------ *)
+
+let counter = ref 0
+let fresh () =
+  incr counter;
+  TVar (Printf.sprintf "a%d" !counter)
+
+(* --- Unification (Robinson) ---------------------------------------- *)
+
+exception Type_error of string
+
+let bind_var a t =
+  if t = TVar a then SMap.empty
+  else if SSet.mem a (ftv_ty t)
+  then raise (Type_error (Printf.sprintf "occurs check: %s in larger type" a))
+  else SMap.singleton a t
+
+let rec unify (t1 : ty) (t2 : ty) : subst =
+  match t1, t2 with
+  | TInt, TInt | TBool, TBool       -> SMap.empty
+  | TVar a, t  | t, TVar a          -> bind_var a t
+  | TFun (a1, b1), TFun (a2, b2)    ->
+      let s1 = unify a1 a2 in
+      let s2 = unify (apply_ty s1 b1) (apply_ty s1 b2) in
+      compose s2 s1
+  | _ ->
+      raise (Type_error "type mismatch")
+
+(* --- Generalisation & instantiation -------------------------------- *)
+
+let generalize (e : env) (t : ty) : scheme =
+  let vs = SSet.diff (ftv_ty t) (ftv_env e) in
+  Forall (SSet.elements vs, t)
+
+let instantiate (Forall (vs, t)) : ty =
+  let s =
+    List.fold_left (fun m v -> SMap.add v (fresh ()) m) SMap.empty vs
+  in
+  apply_ty s t
+
+(* --- Algorithm W --------------------------------------------------- *)
+
+let rec infer (e : env) (ex : expr) : subst * ty =
+  match ex with
+  | EInt  _ -> SMap.empty, TInt
+  | EBool _ -> SMap.empty, TBool
+  | EVar x ->
+      (match SMap.find_opt x e with
+       | Some sch -> SMap.empty, instantiate sch
+       | None     -> raise (Type_error ("unbound variable: " ^ x)))
+  | EFun (x, body) ->
+      let tv  = fresh () in
+      let e'  = SMap.add x (Forall ([], tv)) e in
+      let s, t = infer e' body in
+      s, TFun (apply_ty s tv, t)
+  | EApp (f, a) ->
+      let s1, tf = infer e f in
+      let s2, ta = infer (apply_env s1 e) a in
+      let tv = fresh () in
+      let s3 = unify (apply_ty s2 tf) (TFun (ta, tv)) in
+      compose s3 (compose s2 s1), apply_ty s3 tv
+  | ELet (x, e1, e2) ->
+      let s1, t1 = infer e e1 in
+      let e'     = apply_env s1 e in
+      let sch    = generalize e' t1 in
+      let s2, t2 = infer (SMap.add x sch e') e2 in
+      compose s2 s1, t2
+  | EIf (c, th, el) ->
+      let s1, tc = infer e c in
+      let s2     = unify tc TBool in
+      let s12    = compose s2 s1 in
+      let e1     = apply_env s12 e in
+      let s3, tt = infer e1 th in
+      let s4, te = infer (apply_env s3 e1) el in
+      let s5     = unify (apply_ty s4 tt) te in
+      let s      = compose s5 (compose s4 (compose s3 s12)) in
+      s, apply_ty s te
+  | EBop (op, a, b) ->
+      let s1, ta = infer e a in
+      let s2, tb = infer (apply_env s1 e) b in
+      let s3 = unify (apply_ty s2 ta) TInt in
+      let s4 = unify (apply_ty s3 tb) TInt in
+      let s  = compose s4 (compose s3 (compose s2 s1)) in
+      let result = match op with Eq | Lt -> TBool | _ -> TInt in
+      s, result
+
+(* --- Pretty printing ----------------------------------------------- *)
+
+let rec pp_ty = function
+  | TInt        -> "int"
+  | TBool       -> "bool"
+  | TVar a      -> "'" ^ a
+  | TFun (a, b) ->
+      let l = match a with TFun _ -> "(" ^ pp_ty a ^ ")" | _ -> pp_ty a in
+      l ^ " -> " ^ pp_ty b
+
+let type_of (ex : expr) : ty =
+  counter := 0;
+  let s, t = infer SMap.empty ex in
+  apply_ty s t
+
+(* --- Smoke tests --------------------------------------------------- *)
+
+let () =
+  let cases = [
+    "42",                EInt 42;
+    "true",              EBool true;
+    "fun x -> x",        EFun ("x", EVar "x");
+    "let id = fun x -> x in id 3",
+      ELet ("id", EFun ("x", EVar "x"),
+            EApp (EVar "id", EInt 3));
+    "let id = fun x -> x in (id 1, id true) ~ poly",
+      ELet ("id", EFun ("x", EVar "x"),
+            EBop (Add, EApp (EVar "id", EInt 1),
+                       EIf (EApp (EVar "id", EBool true), EInt 0, EInt 1)));
+    "if true then 1 else 2",
+      EIf (EBool true, EInt 1, EInt 2);
+    "fun f -> fun x -> f (f x)",
+      EFun ("f", EFun ("x",
+                  EApp (EVar "f", EApp (EVar "f", EVar "x"))));
+  ] in
+  List.iter
+    (fun (label, e) ->
+       try
+         let t = type_of e in
+         Printf.printf "%-50s : %s\n" label (pp_ty t)
+       with Type_error msg ->
+         Printf.printf "%-50s : TYPE ERROR (%s)\n" label msg)
+    cases


### PR DESCRIPTION
Tracking issue: #51

## Summary

- Vendors [`brando90/cs421`](https://github.com/brando90/cs421) as a git submodule at `experiments/02_picoml_to_toy_itp/cs421`. The original CS421 coursework — including the MP5 PicoML interpreter / type inferencer — sits alongside the new code as reference.
- Adds `experiments/02_picoml_to_toy_itp/picoml.ml`: a ~150-line single-file Hindley–Milner inferencer. Algorithm W, Robinson unification with occurs check, generalise/instantiate, let-polymorphism, smoke tests. Runs with `ocaml picoml.ml`.
- Adds `experiments/02_picoml_to_toy_itp/README.md`: the roadmap from STLC → HM → System F → λΠ → MLTT core → tactic layer (= toy ITP).
- Adds draft blog post `_drafts/2026-05-12-picoml-to-toy-itp.md`: \"From PicoML to a Toy ITP: Demystifying Lean by Writing the Type Checker Yourself.\" Companion to the in-flight `lean-vs-atp` draft.

## Why this PR

The kernel of an ITP is a type checker. Building one from scratch — starting from CS421's PicoML — is the most direct way to dissolve the impression that Lean 4 is doing something magical. This PR sets up the scaffold (submodule, experiment dir, draft) and lands Phase 1 (HM inference). Phases 2–6 will land in follow-up PRs against the same tracking issue.

## Verification

```
$ cd experiments/02_picoml_to_toy_itp && ocaml picoml.ml
42                                                 : int
true                                               : bool
fun x -> x                                         : 'a1 -> 'a1
let id = fun x -> x in id 3                        : int
let id = fun x -> x in (id 1, id true) ~ poly      : int
if true then 1 else 2                              : int
fun f -> fun x -> f (f x)                          : ('a4 -> 'a4) -> 'a4 -> 'a4
```

The Church-twice case (`('a -> 'a) -> 'a -> 'a`) confirms HM polymorphism is recovered without annotations.

## Test plan

- [x] `ocaml experiments/02_picoml_to_toy_itp/picoml.ml` runs clean
- [x] Submodule clones successfully (`git submodule update --init`)
- [ ] Local Jekyll preview of `_drafts/2026-05-12-picoml-to-toy-itp.md` renders cleanly (will check before promoting to `_posts/`)
- [ ] Cross-link from `lean-vs-atp.md` updated once that post is published

## Next up (tracked in #51)

- Phase 2: full PicoML — lexer/parser, ADTs, lists, pattern matching.
- Phase 3: bidirectional checker for System F.
- Phase 4+: λΠ → MLTT-ish core → tactics → proof of `n + 0 = n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)