### PR TITLE
Add experiments/03_unary_nats: Peano-style UnaryNat in Lean 4

### DIFF
--- a/experiments/03_unary_nats/.gitignore
+++ b/experiments/03_unary_nats/.gitignore
@@ -1,0 +1,5 @@
+.lake/
+build/
+*.olean
+*.ilean
+*.c

--- a/experiments/03_unary_nats/README.md
+++ b/experiments/03_unary_nats/README.md
@@ -1,0 +1,30 @@
+# 03 — Unary Nats
+
+Lean 4 worked example: define the unary natural numbers from scratch
+(Peano-style `zero` / `succ`), define addition two ways (recurse on
+the left or right argument), and prove basic identities.
+
+Source material:
+
+- Gist: <https://gist.github.com/brando90/ed63fd474647825881987baaa1f26ead>
+- Tutorial video: <https://www.youtube.com/watch?v=ZVaWw2LfH78&list=PLB3sDpSRdrOt68MTR6kdI0Jc85Uuw1YWV&index=2&t=11s>
+
+## Build
+
+```bash
+cd experiments/03_unary_nats
+lake build
+```
+
+Requires `elan` and Lean 4 (see `lean-toolchain`). No Mathlib dependency.
+
+## What's in `UnaryNats.lean`
+
+- `inductive UnaryNat` with constructors `zero` and `succ`
+- `add_left` — addition by recursion on the *first* argument
+- `add_right` — addition by recursion on the *second* argument
+- `infixl:65 "+" => add_left` — local `+` notation
+- Theorems:
+  - `add_zero_is_zero : zero + zero = zero`
+  - `zero_add_n_eq_n  : ∀ n, zero + n = n` (proved by `rfl` — holds by computation)
+  - `n_add_zero_eq_n  : ∀ n, n + zero = n` (proved by induction — does *not* hold by computation)

--- a/experiments/03_unary_nats/UnaryNats.lean
+++ b/experiments/03_unary_nats/UnaryNats.lean
@@ -1,0 +1,80 @@
+/-
+Unary natural numbers, Peano style.
+Companion file to the gist:
+  https://gist.github.com/brando90/ed63fd474647825881987baaa1f26ead
+and the tutorial video:
+  https://www.youtube.com/watch?v=ZVaWw2LfH78&list=PLB3sDpSRdrOt68MTR6kdI0Jc85Uuw1YWV&index=2
+-/
+
+inductive UnaryNat : Type
+| zero : UnaryNat
+| succ : UnaryNat → UnaryNat
+  deriving Repr
+
+#check UnaryNat
+#check UnaryNat.zero
+#check UnaryNat.succ
+#check UnaryNat.succ UnaryNat.zero
+
+-- 0
+#eval UnaryNat.zero
+
+-- 1
+#eval (UnaryNat.succ UnaryNat.zero)
+
+-- 2
+#eval (UnaryNat.succ (UnaryNat.succ UnaryNat.zero))
+
+-- open the namespace for UnaryNat
+open UnaryNat
+
+#check zero
+
+def add_left : UnaryNat → UnaryNat → UnaryNat
+  | zero,    n => n
+  | succ m', n => succ (add_left m' n)
+
+#check add_left zero
+#eval add_left zero zero
+#eval add_left zero (succ zero)
+#eval add_left (succ zero) zero
+
+def add_right (m n : UnaryNat) : UnaryNat :=
+  match n with
+  | zero    => m
+  | succ n' => succ (add_right m n')
+
+#eval add_right zero zero
+
+-- TODO: prove add_right == add_left (extensionally)
+
+infixl:65 " + " => add_left
+
+#eval zero + zero  -- add(0, 0)
+-- a + b + c  parses as  add(add(a, b), c)  because infixl
+
+theorem add_zero_is_zero : zero + zero = zero := rfl
+
+-- 0 + n = n  (holds by computation: matches the first equation of add_left)
+theorem zero_add_n_eq_n : ∀ n : UnaryNat, zero + n = n := by
+  intro n
+  rfl
+  -- alternatives:
+  --   simp [add_left]
+  --   rw  [add_left]
+
+-- print the proof term
+#print zero_add_n_eq_n
+
+theorem zero_add_n_eq_n' (n : UnaryNat) : zero + n = n := by rfl
+#print zero_add_n_eq_n'
+
+-- n + 0 = n   (does NOT hold by computation — need induction on n)
+theorem n_add_zero_eq_n : ∀ n : UnaryNat, n + zero = n := by
+  intro n
+  induction n with
+  | zero      => rfl
+  -- alternative: | succ n' ih => rw [add_left]; rw [ih]
+  | succ n' ih => rw [add_left, ih]
+
+#print n_add_zero_eq_n

--- a/experiments/03_unary_nats/lake-manifest.json
+++ b/experiments/03_unary_nats/lake-manifest.json
@@ -1,0 +1,5 @@
+{"version": "1.1.0",
+ "packagesDir": ".lake/packages",
+ "packages": [],
+ "name": "unaryNats",
+ "lakeDir": ".lake"}

--- a/experiments/03_unary_nats/lakefile.toml
+++ b/experiments/03_unary_nats/lakefile.toml
@@ -1,0 +1,5 @@
+name = "unaryNats"
+defaultTargets = ["UnaryNats"]
+
+[[lean_lib]]
+name = "UnaryNats"

--- a/experiments/03_unary_nats/lean-toolchain
+++ b/experiments/03_unary_nats/lean-toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:v4.18.0


### PR DESCRIPTION
## Summary
- New experiment folder `experiments/03_unary_nats/` with self-contained Lean 4 project (no Mathlib).
- `UnaryNat` inductive type, two definitions of addition (`add_left` recurses on first arg, `add_right` on second), and three theorems demonstrating the computation-vs-induction split: `add_zero_is_zero`, `zero_add_n_eq_n` (proved by `rfl`), and `n_add_zero_eq_n` (requires induction).
- Companion to the gist <https://gist.github.com/brando90/ed63fd474647825881987baaa1f26ead> and tutorial video <https://www.youtube.com/watch?v=ZVaWw2LfH78&list=PLB3sDpSRdrOt68MTR6kdI0Jc85Uuw1YWV&index=2>.

## Test plan
- [x] `cd experiments/03_unary_nats && lake build` → ✔ Built UnaryNats; all `#check`/`#eval`/`#print` produce expected output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)