### PR TITLE
CV updates for Harmonic Grant: Stanford AI for Lean, AWS Lean 4 internship, new publications

### DIFF
--- a/cvs_tex/cv_long.tex
+++ b/cvs_tex/cv_long.tex
@@ -160,7 +160,17 @@ Stanford, CA, 94305. \hfill
 		\item Machine Learning PhD student with professor Sanmi Koyejo conducting research on data-centric machine learning for Frontier Models, formal reasoning and verification, and scaling laws for LLMs.
 		\item Published award-winning work challenging prevailing notions of ``emergent abilities'' in large language models (NeurIPS Outstanding Paper Award 2023).
 		\item Leading development of VeriBench and Putnam-AXIOM benchmarks for evaluating AI mathematical reasoning (both accepted at ICML 2025).
+		\item Leading ongoing benchmarks for repository-level and semantic autoformalization: \href{https://github.com/brando90/veribench-dt}{VeriBench-DT} (trustworthy agentic autoformalization via differential testing between Python source, gold Lean reference, and model output) and \href{https://github.com/brando90/veribench-deps}{VeriBench-Deps} (multi-file autoformalization of Python repos into Lean 4, introducing the Axiom Trust Boundary metric and a 2$\times$2 provenance/effect dependency taxonomy).
+		\item Advising \href{https://github.com/Stanford-AI-for-LEAN-Club/lean-ebm}{lean-ebm}, a Stanford AI for LEAN Club project unifying policy and value into a single Energy-Based Model with Langevin-dynamics tactic search, plus a synthetic-data track generating high-quality Lean 4 proof data for MCTS-guided theorem proving.
 		\item Research mentor for undergraduate and master's students focused on data quality for Foundation Models.
+	\end{itemize}
+	\vspace{5 pt}
+
+	\textbf{Amazon Web Services (AWS)} - Cupertino, CA \hfill \emph{June 2024 - September 2024}\\
+	\emph{Applied Scientist Intern}\\
+	\vspace*{-3pt}
+	\begin{itemize} \itemsep -2pt
+		\item Applied Scientist intern developing LLMs for the Lean 4 proof assistant and programming language for formal verification.
 	\end{itemize}
 	\vspace{5 pt}
 
@@ -169,7 +179,7 @@ Stanford, CA, 94305. \hfill
 	\vspace*{-3pt}
 	\begin{itemize} \itemsep -2pt
 		\item Made key contributions to Morph Prover v0-7B, the first frontier model for the Lean 4 formal verification programming language.
-		\item Helped launch Moogle.ai, the first search engine for verified code in Lean.
+		\item Key contributor to Moogle.ai, the first search engine for verified code in Lean; designed and built the embedding-based vector database powering semantic search over Mathlib.
 	\end{itemize}
 	\vspace{5 pt}
 
@@ -177,7 +187,7 @@ Stanford, CA, 94305. \hfill
 	\emph{AI Research Consultant}\\
 	\vspace*{-3pt}
 	\begin{itemize} \itemsep -2pt
-		\item Deployed AI agent-based systems to transform sales performance.
+		\item Advised the team on AI agent-based systems to transform sales performance (consulting engagement).
 		\item Company featured in Forbes Mexico.
 	\end{itemize}
 	\vspace{5 pt}
@@ -296,9 +306,68 @@ Stanford, CA, 94305. \hfill
     \\
     (Preprint 2025)
 
+    \vspace{10pt}
+    {S. Barkallah, S. Daruru, B. Miranda, L. Aniva, A. Nie, S. Koyejo,
+    VeriBench-FTP: A Formal Theorem Proving Benchmark in Lean 4 for Code Verification.}
+    \\
+    (\textbf{5th Workshop on Mathematical Reasoning and AI @ NeurIPS 2025})
+
+    \vspace{10pt}
+    \href{https://arxiv.org/abs/2502.15795}
+    {W. Chan, M. Souliman, J. Nordhagen, B. Miranda, E. Obbad, S. Koyejo,
+    Lean-ing on Quality: How High-Quality Data Beats Diverse Multilingual Data in Autoformalization.}
+    \\
+    (Preprint 2025)
+
+    \vspace{10pt}
+    \href{https://arxiv.org/abs/2509.24012}
+    {R. Schaeffer, N. Levi, B. Miranda, S. Koyejo,
+    Pretraining Scaling Laws for Generative Evaluations of Language Models.}
+    \\
+    (Preprint 2025)
+
+    \vspace{10pt}
+    \href{https://arxiv.org/abs/2509.23963}
+    {R. Schaeffer, N. Levi, A. Kirsch, T. Guenais, B. Miranda, E. Obbad, S. Koyejo,
+    Evaluating the Robustness of Chinchilla Compute-Optimal Scaling.}
+    \\
+    (Preprint 2025)
+
+    \vspace{10pt}
+    \href{https://arxiv.org/abs/2510.06261}
+    {Z. Zhou, C. Cao, X. Feng, X. Li, Z. Li, X. Lu, J. Yao, W. Huang, L. Xu, T. Cheng, B. Miranda, et al.,
+    AlphaApollo: Orchestrating Foundation Models and Professional Tools into a Self-Evolving System for Deep Agentic Reasoning.}
+    \\
+    (Preprint 2025)
+
+    \vspace{10pt}
+    {R. Schaeffer, K. Liu, B. Miranda, A. M. Ahmed, N. Mireshghallah, S. Koyejo,
+    The Contamination Paradox: Why Test Set Leakage Can Be Both Potent and Negligible.}
+    \\
+    (NeurIPS 2025 Workshop on Evaluating the Evolving LLM Lifecycle)
+
     \vspace{12pt}
     \textbf{\large 2024}
     \vspace{4pt}
+
+    \vspace{10pt}
+    \href{https://arxiv.org/abs/2410.18194}
+    {E. Obbad, I. Mlauzi, B. Miranda, R. Schaeffer, K. Obbad, S. Bedi, S. Koyejo,
+    ZIP-FIT: Embedding-Free Data Selection via Compression-Based Alignment.}
+    \\
+    (\textbf{ICML 2025}; arXiv 2024) \href{https://github.com/stair-lab/ZIP-FIT}{[Code]}
+
+    \vspace{10pt}
+    {J. Rotella, Z. Qin, A. Z. H. Yang, B. Miranda, M. E. A. Seddik, J. Zuo, H. Hacid, et al.,
+    Synthetic Theorem Generation in Lean.}
+    \\
+    (Preprint 2024)
+
+    \vspace{10pt}
+    {K. Chawla, A. Sahai, M. DePavia, B. Miranda,
+    A Systematic Study of the Role of Data Quality and Alignment for Fine-tuning LLMs for Enhanced Autoformalization.}
+    \\
+    (The Second Tiny Papers Track at ICLR 2024)
 
     \vspace{10pt}
     \href{https://openreview.net/forum?id=wvFnqVVUhN}

--- a/cvs_tex/cv_long.tex
+++ b/cvs_tex/cv_long.tex
@@ -915,7 +915,18 @@ Stanford, CA, 94305. \hfill
 	\emph{Research Mentor}\\
 	\vspace*{-3pt}
 	\begin{itemize} \itemsep -2pt  % reduce space between items
-    	\item Research mentor with an Undergraduate and two master students on the role of data quality on the ability of Foundation Models to do in context learning. 
+    	\item Research mentor with an Undergraduate and two master students on the role of data quality on the ability of Foundation Models to do in context learning.
+	\end{itemize}
+	\vspace{5 pt}
+
+ 	\textbf{Stanford AI for Lean (Student Organization)} - Stanford, CA \hfill \emph{February 2026 - Present}\\
+	\emph{President and Founder}\\
+	\vspace*{-3pt}
+	\begin{itemize} \itemsep -2pt  % reduce space between items
+    	\item Founded and lead a Stanford student-run club at the intersection of AI and formal theorem proving in Lean 4
+    	\item Run weekly meetings and direct open-source research projects on AI-assisted theorem proving, autoformalization, and Mathlib-scale formal verification
+    	\item Mission: educate students on Lean 4 and formal verification, research new methods for AI-assisted theorem proving, and collaborate with the global Lean community
+    	\item Website: \href{https://aiforlean.org}{aiforlean.org}
 	\end{itemize}
 	\vspace{5 pt}
 

--- a/cvs_tex/cv_short_llm.tex
+++ b/cvs_tex/cv_short_llm.tex
@@ -200,7 +200,33 @@ Stanford, CA, 94305. \hfill
     \textbf{Position: Machine Learning Conferences Should Establish a `Refutations and Critiques' Track} (2025)\\
     \emph{Rylan Schaeffer, Jiaqi Kazdan, Yarin Denisov-Blanch, Brando Miranda, Max Gerstgrasser, et al.}\\
     Preprint 2025
-    
+
+    \vspace{10pt}
+    \textbf{VeriBench-FTP: A Formal Theorem Proving Benchmark in Lean 4 for Code Verification} (2025)\\
+    \emph{Sami Barkallah, Sathvik Daruru, Brando Miranda, Leni Aniva, Anima Nie, Sanmi Koyejo}\\
+    \textbf{5th Workshop on Mathematical Reasoning and AI @ NeurIPS 2025}
+
+    \vspace{10pt}
+    \textbf{Lean-ing on Quality: How High-Quality Data Beats Diverse Multilingual Data in Autoformalization} (2025)\\
+    \emph{Willy Chan, Matteo Souliman, Jackson Nordhagen, Brando Miranda, Elyas Obbad, Sanmi Koyejo}\\
+    Preprint 2025 \href{https://arxiv.org/abs/2502.15795}{[arXiv]}
+
+    \vspace{10pt}
+    \textbf{ZIP-FIT: Embedding-Free Data Selection via Compression-Based Alignment} (2024)\\
+    \emph{Elyas Obbad, Iddah Mlauzi, Brando Miranda, Rylan Schaeffer, Kamal Obbad, Suhana Bedi, Sanmi Koyejo}\\
+    \textbf{International Conference on Machine Learning (ICML) 2025}\\
+    \href{https://arxiv.org/abs/2410.18194}{[arXiv]} \href{https://github.com/stair-lab/ZIP-FIT}{[Code]}
+
+    \vspace{10pt}
+    \textbf{Synthetic Theorem Generation in Lean} (2024)\\
+    \emph{Jacob Rotella, Zijian Qin, Andrew Z. H. Yang, Brando Miranda, Mohamed El Amine Seddik, Jingxuan Zuo, Hakim Hacid, et al.}\\
+    Preprint 2024
+
+    \vspace{10pt}
+    \textbf{A Systematic Study of the Role of Data Quality and Alignment for Fine-tuning LLMs for Enhanced Autoformalization} (2024)\\
+    \emph{Keshav Chawla, Aditya Sahai, Marco DePavia, Brando Miranda}\\
+    \textbf{The Second Tiny Papers Track at ICLR 2024}
+
     \vspace{10pt}
     \textbf{Failures to Find Transferable Image Jailbreaks Between Vision-Language Models} (2024)\\
     \emph{Rylan Schaeffer, Dan Valentine, Luke Bailey, James Chua, et al., Brando Miranda, et al., Sanmi Koyejo, Ethan Perez}\\
@@ -267,7 +293,17 @@ Stanford, CA, 94305. \hfill
 		\item Conducting research on data-centric machine learning for Frontier Models, formal reasoning and verification, and scaling laws for LLMs
 		\item Published award-winning work challenging prevailing notions of "emergent abilities" in large language models
 		\item Leading development of VeriBench and Putnam-AXIOM benchmarks for evaluating AI mathematical reasoning
+		\item Leading ongoing Lean 4 benchmarks: \href{https://github.com/brando90/veribench-dt}{VeriBench-DT} (trustworthy agentic autoformalization via differential testing) and \href{https://github.com/brando90/veribench-deps}{VeriBench-Deps} (repo-level Python$\to$Lean 4 with Axiom Trust Boundary metric)
+		\item Advising \href{https://github.com/Stanford-AI-for-LEAN-Club/lean-ebm}{lean-ebm} (Stanford AI for LEAN Club): Energy-Based Models for Lean 4 theorem proving with Langevin-dynamics tactic search
 		\item Research mentor for undergraduate and master's students focused on data quality for Foundation Models
+	\end{itemize}
+	\vspace{5 pt}
+
+    \textbf{Amazon Web Services (AWS)} - Cupertino, CA \hfill \emph{June 2024 - September 2024}\\
+	\emph{Applied Scientist Intern}\\
+	\vspace*{-3pt}
+	\begin{itemize} \itemsep -2pt
+		\item Applied Scientist intern developing LLMs for the Lean 4 proof assistant and programming language for formal verification
 	\end{itemize}
 	\vspace{5 pt}
 
@@ -276,7 +312,7 @@ Stanford, CA, 94305. \hfill
 	\vspace*{-3pt}
 	\begin{itemize} \itemsep -2pt
 		\item Made key contributions to Morph Prover v0-7B, the first frontier model for Lean 4 formal verification language
-		\item Helped launch Moogle.ai, the first search engine for verified code in Lean
+		\item Key contributor to Moogle.ai, the first search engine for verified code in Lean; designed and built the embedding-based vector database
 	\end{itemize}
 	\vspace{5 pt}
 	
@@ -284,7 +320,7 @@ Stanford, CA, 94305. \hfill
 	\emph{AI Research Consultant}\\
 	\vspace*{-3pt}
 	\begin{itemize} \itemsep -2pt
-		\item Deployed AI agent-based systems to transform sales performance
+		\item Advised the team on AI agent-based systems to transform sales performance (consulting engagement)
 		\item Company featured in Forbes Mexico
 	\end{itemize}
 	\vspace{5 pt}
@@ -363,6 +399,7 @@ Stanford, CA, 94305. \hfill
         \item Introduction to Algorithms (6.006) with Prof. Nancy Lynch, Bruce Tidor and Aleksander Madry
         \item Design \& Analysis of Algorithms (6.046) with Prof. Shafi Goldwasser, Dana Moshkovitz, Nir Shavit
         \item Introduction to Machine Learning (6.036) with Prof. Tommi Jaakkola, Suvrit Sra \& Regina Barzilay
+        \item Mathematics for Computer Science (6.042) with Prof. F. Thomson Leighton \& Ankur Moitra
 	\end{itemize}
 \end{body}
 

--- a/cvs_tex/cv_short_llm.tex
+++ b/cvs_tex/cv_short_llm.tex
@@ -385,6 +385,7 @@ Stanford, CA, 94305. \hfill
 \vspace*{-3pt}
 \begin{itemize} \itemsep -2pt
     \item Reviewer for ICLR 2020, JMLR 2018
+    \item Founder \& President, \href{https://aiforlean.org}{Stanford AI for Lean} --- student club on AI for Lean 4 theorem proving (2026 -- Present)
     \item Graduate advisor for Latinos in Computer Science (LCS) at UIUC
     \item Founded "Stanford Bachata Sensual \& Brazilian Zouk" and "UIUC Bachata Sensual \& Zouk" official student organizations
 \end{itemize}


### PR DESCRIPTION
Superseded by #62 — main moved the CV files to `professional_documents/cvs/` and already incorporated most of the additions from this PR (Stanford AI for Lean, AWS Lean 4 internship, ZIP-FIT, VeriBench-FTP, Lean-ing on Quality, Synthetic Theorem Generation, Data Quality & Alignment for Autoformalization, 6.042 TA, Veritas Scholar, etc.). The remaining deltas (VeriBench-DT, VeriBench-Deps, lean-ebm, Moogle.ai embedding-database detail) are applied in #62 directly against the new file paths.