### PR TITLE
Add VeriBench-DT, VeriBench-Deps, lean-ebm to CV; clarify Moogle.ai contribution

### DIFF
--- a/professional_documents/cvs/cv_long.tex
+++ b/professional_documents/cvs/cv_long.tex
@@ -192,7 +192,7 @@ AI for formal mathematics, Lean 4 theorem proving, theorem generation, autoforma
 
 	\textbf{Morph Labs} - Remote \hfill \emph{October 2023 - December 2023}\\
 	\emph{Machine Learning Research Scientist Consultant}\\
-	Contributed to Morph Prover v0 7b and Moogle.ai, a search engine for verified Lean code.\\
+	Key contributor to Morph Prover v0 7b and Moogle.ai; designed and built the embedding-based vector database powering Moogle's semantic search over Mathlib.\\
 	\vspace{8pt}
 
 	\textbf{Wise Agents} - Stanford Spin-out \hfill \emph{2023}\\
@@ -250,10 +250,13 @@ AI for formal mathematics, Lean 4 theorem proving, theorem generation, autoforma
 	\begin{itemize} \itemsep -2pt
 		\item \textbf{\href{https://openreview.net/forum?id=rWkGFmnSNl}{VeriBench}}: End-to-end Lean 4 benchmark for evaluating AI-generated code with formal verification proofs.
 		\item \textbf{\href{https://openreview.net/forum?id=wDjOpXKgtU}{VeriBench-FTP}}: Formal theorem-proving benchmark in Lean 4 for code verification.
+		\item \textbf{\href{https://github.com/brando90/veribench-dt}{VeriBench-DT}}: Trustworthy agentic autoformalization benchmark verifying original-code equivalence via differential testing across Python source, gold Lean reference, and model output (Three-Way Semantic Triangulation).
+		\item \textbf{\href{https://github.com/brando90/veribench-deps}{VeriBench-Deps}}: Repository-level autoformalization benchmark for multi-file Python programs into Lean 4; introduces the Axiom Trust Boundary (ATB) metric and a 2$\times$2 provenance/effect dependency taxonomy.
+		\item \textbf{\href{https://github.com/Stanford-AI-for-LEAN-Club/lean-ebm}{lean-ebm}}: Energy-Based Models for Lean 4 theorem proving --- Stanford AI for Lean Club project unifying policy and value via Langevin-dynamics tactic search; pairs a synthetic-data track with an EBM-based MCTS proof-search fallback.
 		\item \textbf{\href{https://openreview.net/forum?id=kqj2Cn3Sxr}{Putnam-AXIOM}}: Functional and static benchmark for higher-level LLM mathematical reasoning.
 		\item \textbf{\href{https://huggingface.co/datasets/3ricme/Putnam-AXIOM-Grading}{Putnam-AXIOM-Grading}}: Human-graded 1,000-solution benchmark for Putnam-style partial-credit mathematical evaluation.
 		\item \textbf{\href{https://link.springer.com/chapter/10.1007/978-3-031-90643-5_6}{Pantograph}}: Machine-to-machine interface for Lean 4 theorem proving, reasoning, and data extraction.
-		\item \textbf{\href{https://huggingface.co/morph-labs/morph-prover-v0-7b}{Morph Prover v0 7b} and \href{https://www.moogle.ai/}{Moogle.ai}}: Lean 4 proof model and search engine for verified Lean code developed with Morph Labs.
+		\item \textbf{\href{https://huggingface.co/morph-labs/morph-prover-v0-7b}{Morph Prover v0 7b} and \href{https://www.moogle.ai/}{Moogle.ai}}: Lean 4 proof model and verified-code search engine developed with Morph Labs; designed and built the embedding-based vector database powering Moogle's semantic search over Mathlib.
 		\item \textbf{\href{https://alphaapollo.org/}{AlphaApollo}}: Agentic reasoning framework for tool-integrated reasoning, agentic post-training, and self-evolving verification workflows.
 		\item \textbf{\href{https://github.com/dhoemenk97-star/AlphaDiana}{AlphaDiana}}: Harness-aware evaluation system for open agents on verifiable reasoning tasks with trajectory logging.
 		\item \textbf{\href{https://github.com/brando90/ultimate-utils}{ultimate-utils}}: Reusable ML and research-engineering utility library for experiment workflows.

--- a/professional_documents/cvs/cv_short.tex
+++ b/professional_documents/cvs/cv_short.tex
@@ -344,9 +344,11 @@
 	\vspace{12pt}
 	\begin{itemize} \itemsep -2pt
 		\item \textbf{\href{https://openreview.net/forum?id=rWkGFmnSNl}{VeriBench}} and \textbf{\href{https://openreview.net/forum?id=wDjOpXKgtU}{VeriBench-FTP}}: Lean 4 verification benchmarks for AI-generated code and theorem-proving code verification
+		\item \textbf{\href{https://github.com/brando90/veribench-dt}{VeriBench-DT}} and \textbf{\href{https://github.com/brando90/veribench-deps}{VeriBench-Deps}}: Lean 4 autoformalization benchmarks --- differential-testing trustworthiness and repository-level Python$\to$Lean with the Axiom Trust Boundary metric
+		\item \textbf{\href{https://github.com/Stanford-AI-for-LEAN-Club/lean-ebm}{lean-ebm}}: Energy-Based Models for Lean 4 theorem proving (Stanford AI for Lean Club project)
 		\item \textbf{\href{https://openreview.net/forum?id=kqj2Cn3Sxr}{Putnam-AXIOM}} and \textbf{\href{https://huggingface.co/datasets/3ricme/Putnam-AXIOM-Grading}{Putnam-AXIOM-Grading}}: LLM mathematical reasoning benchmark and human-graded Putnam-style partial-credit benchmark
 		\item \textbf{\href{https://link.springer.com/chapter/10.1007/978-3-031-90643-5_6}{Pantograph}}: Lean machine-to-machine theorem-proving interface
-		\item \textbf{\href{https://huggingface.co/morph-labs/morph-prover-v0-7b}{Morph Prover v0 7b} / \href{https://www.moogle.ai/}{Moogle.ai}}: Lean 4 proof model and verified-code search engine developed with Morph Labs
+		\item \textbf{\href{https://huggingface.co/morph-labs/morph-prover-v0-7b}{Morph Prover v0 7b} / \href{https://www.moogle.ai/}{Moogle.ai}}: Lean 4 proof model and verified-code search engine developed with Morph Labs; designed and built the embedding-based vector database powering Moogle's semantic search over Mathlib
 		\item \textbf{\href{https://alphaapollo.org/}{AlphaApollo}} and \textbf{\href{https://github.com/dhoemenk97-star/AlphaDiana}{AlphaDiana}}: agentic reasoning and harness-aware evaluation systems for verifiable reasoning
 		\item \textbf{\href{https://github.com/brando90/ultimate-utils}{ultimate-utils}}: reusable ML and research-engineering utility library
 	\end{itemize}


### PR DESCRIPTION
## Summary

Adds three ongoing Lean 4 research artifacts to both CVs (`professional_documents/cvs/cv_long.tex`, `cv_short.tex`) and clarifies Brando's Moogle.ai contribution.

### New artifacts in Research Artifacts & Systems
- [VeriBench-DT](https://github.com/brando90/veribench-dt) — trustworthy agentic autoformalization via differential testing (Three-Way Semantic Triangulation across Python source, gold Lean reference, model output)
- [VeriBench-Deps](https://github.com/brando90/veribench-deps) — repository-level Python→Lean 4 autoformalization with the Axiom Trust Boundary metric and a 2×2 provenance/effect dependency taxonomy
- [lean-ebm](https://github.com/Stanford-AI-for-LEAN-Club/lean-ebm) — Energy-Based Models for Lean 4 theorem proving (Stanford AI for Lean Club)

### Moogle.ai clarification
Strengthens the Moogle.ai entry in long-CV Professional Experience and in both CVs' Research Artifacts section: "key contributor who designed and built the embedding-based vector database powering Moogle's semantic search over Mathlib."

## Why
Prepares the CVs for the Harmonic Grant application by surfacing three ongoing Lean autoformalization / theorem-proving projects that are not yet captured anywhere on the CV, and correcting the role accuracy on Moogle.ai.

## Test plan
- [ ] `pdflatex professional_documents/cvs/cv_long.tex` builds without errors
- [ ] `pdflatex professional_documents/cvs/cv_short.tex` builds without errors
- [ ] All new GitHub repo hyperlinks resolve

Supersedes #61 (stale file paths under `cvs_tex/`).

https://claude.ai/code/session_01DbG3BPbzgH4j4yqk76MUR4

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbG3BPbzgH4j4yqk76MUR4)_