### PR TITLE
Publish velocity & vectoring research posts (work-in-progress)

### DIFF
--- a/_posts/2026-04-16-vectoring-in-research.md
+++ b/_posts/2026-04-16-vectoring-in-research.md
@@ -4,7 +4,11 @@ title: "Vectoring: Attack the Biggest Uncertainty First"
 date: 2026-04-16
 ---
 
-*Brando Miranda — April 2026*
+*Brando Miranda — April 2026 · ~6 min read*
+
+**TL;DR.** **[In development — work in progress; published early while I refine it.]** The hardest part of research is choosing what to attack next when everything is uncertain. **Vectoring** (Michael Bernstein's term) is the answer: pick the single dimension where, if you are wrong, the whole project falls apart, and reduce that uncertainty first with the cheapest experiment that actually answers it. Split the work into **core** (the central assumption you test now) and **periphery** (scaffold it with the laziest thing that works). Worked examples: the *Mirage* emergent-abilities paper and a study of internet trolling. Vector first, then velocity.
+
+---
 
 Most research advice I got early on was useless because it assumed I already knew what to work on. The hardest part of a research project is not executing a plan — it is choosing what to attack next when everything is uncertain and nothing is proven. The single most important technique I teach in CS197 for this is what Michael Bernstein calls **vectoring**: identify the direction of biggest uncertainty in your project, and reduce it first.
 

--- a/_posts/2026-04-16-velocity-in-research.md
+++ b/_posts/2026-04-16-velocity-in-research.md
@@ -4,7 +4,11 @@ title: "Velocity in Research"
 date: 2026-04-16
 ---
 
-*Brando Miranda — April 2026*
+*Brando Miranda — April 2026 · ~5 min read*
+
+**TL;DR.** **[In development — work in progress; published early while I refine it.]** Research feels slow because we grade ourselves on whether experiments *worked* — something largely outside our control. The better metric is **velocity**: the rate at which you reduce uncertainty in a chosen direction. Vectoring picks the riskiest question; velocity answers it as cheaply as possible. Be ruthless about core versus periphery (fake, mock, or skip everything inessential), and lean on $v = d/t$ — the fastest way to go faster is almost never doing *more*, it's doing less, faster, and ignoring the rest.
+
+---
 
 Most of my students arrive with the same complaint. Research feels slow. Weeks disappear, experiments fail, deadlines pass, and the advisor starts to look worried. I've been there myself, more than once. The instinct is to work harder — longer hours, more code, a bigger system. That instinct is almost always wrong.
 


### PR DESCRIPTION
## Why the velocity & vectoring blogs weren't public

They were complete posts but sat in `_drafts/`, which `_config.yml` excludes from publishing (`exclude: [... _drafts/ ...]`). Jekyll never builds drafts into the live site, so they were invisible at `brando90.github.io/brandomiranda/`.

## What this PR does

Same approach as the AR error-compounding post (published as a work-in-progress):

- **Move** `2026-04-16-velocity-in-research.md` and `2026-04-16-vectoring-in-research.md` from `_drafts/` → `_posts/` so they go live and auto-appear in the `blog.md` index (Minima `home` layout lists all `_posts/`).
- **Normalize headers** to the canonical blog format: read-time byline (`*Brando Miranda — April 2026 · ~X min read*`), a `**TL;DR.**` paragraph, and the `---` horizontal rule before the body.
- **Add a work-in-progress disclaimer** at the start of each TL;DR: `**[In development — work in progress; published early while I refine it.]**` — mirroring the AR post's disclaimer.

`scripts/normalize_post_headers.py` reports no further changes (headers are canonical).

https://claude.ai/code/session_011k7wNy3UFXy3FYSizSWBsm

---
_Generated by [Claude Code](https://claude.ai/code/session_011k7wNy3UFXy3FYSizSWBsm)_