### PR TITLE
Cite Bernstein/CS197 + add References bib to velocity & vectoring posts

### DIFF
--- a/_posts/2026-04-16-vectoring-in-research.md
+++ b/_posts/2026-04-16-vectoring-in-research.md
@@ -10,7 +10,7 @@ date: 2026-04-16
 
 ---
 
-Most research advice I got early on was useless because it assumed I already knew what to work on. The hardest part of a research project is not executing a plan — it is choosing what to attack next when everything is uncertain and nothing is proven. The single most important technique I teach in CS197 for this is what Michael Bernstein calls **vectoring**: identify the direction of biggest uncertainty in your project, and reduce it first.
+Most research advice I got early on was useless because it assumed I already knew what to work on. The hardest part of a research project is not executing a plan — it is choosing what to attack next when everything is uncertain and nothing is proven. The single most important technique I teach in [CS197](https://cs197.stanford.edu/) for this is what [Michael Bernstein](https://hci.stanford.edu/msb/) at Stanford calls **vectoring**: identify the direction of biggest uncertainty in your project, and reduce it first.
 
 This is one of two skills that separate researchers who ship from researchers who flounder. The other is velocity — the speed at which you reduce risk once you have picked a direction. They operate in a tight loop. Pick the wrong vector and velocity does not save you; move too slowly on the right vector and the project dies anyway. Today I want to focus on the picking.
 
@@ -78,3 +78,9 @@ One trick I use on myself: put the result on a calendar as if I have to present 
 - **Iterate honestly.** When a vector resolves, new unknowns appear — that is the job. Reprioritize. Unexpected results are a gift, not a failure.
 
 Iteration beats planning. Hemingway, Picasso, every researcher I admire — all wrong on the first try. Assume you will be too, and make your first try cheap.
+
+## References
+
+- Michael S. Bernstein. *CS197: Computer Science Research* — Stanford University. **Vectoring** is Bernstein's term, taught in CS197; this post is my take on it. [cs197.stanford.edu](https://cs197.stanford.edu/) · [Bernstein's homepage](https://hci.stanford.edu/msb/).
+- Rylan Schaeffer, **Brando Miranda**, Sanmi Koyejo. *Are Emergent Abilities of Large Language Models a Mirage?* Neural Information Processing Systems (NeurIPS), 2023 — Outstanding Main Track Paper Award & Oral. [arXiv:2304.15004](https://arxiv.org/abs/2304.15004) · [OpenReview](https://openreview.net/forum?id=ITw9edRDlD). The *Mirage* emergent-abilities walkthrough in this post.
+- Justin Cheng, Michael Bernstein, Cristian Danescu-Niculescu-Mizil, Jure Leskovec. *Anyone Can Become a Troll: Causes of Trolling Behavior in Online Discussions.* CSCW, 2017. [arXiv:1702.01119](https://arxiv.org/abs/1702.01119). The ~16M CNN-comments trolling study used as the non-ML walkthrough.

--- a/_posts/2026-04-16-velocity-in-research.md
+++ b/_posts/2026-04-16-velocity-in-research.md
@@ -24,7 +24,7 @@ Gowers — the mathematician — put it well. Research is an iterative process o
 
 ## Vectoring sets the question, velocity answers it
 
-Vectoring and velocity are different jobs. Vectoring is picking the most uncertain assumption in your project — the one that, if wrong, kills everything downstream. It's an abstract question: is assumption X actually valid? Is the metric the reason LLMs look like they have emergent jumps?
+Vectoring and velocity are different jobs. Vectoring — a term I borrow from [Michael Bernstein](https://hci.stanford.edu/msb/)'s [CS197](https://cs197.stanford.edu/) at Stanford — is picking the most uncertain assumption in your project — the one that, if wrong, kills everything downstream. It's an abstract question: is assumption X actually valid? Is the metric the reason LLMs look like they have emergent jumps?
 
 Velocity is what you do after vectoring. You have the question; now how do you answer it this week, with the least possible work? This separation matters because it's easy to conflate them and end up prototyping the wrong thing fast, or the right thing slowly. Pick the question first. Then sprint.
 
@@ -68,3 +68,10 @@ A few practices I actually run on myself:
 - Lean on 1/t. The fastest way to increase velocity is almost never doing more — it's doing less, faster, and ignoring the rest.
 
 If you're stuck right now, walk home without your headphones and ask yourself one thing: what is the actual question this week, and what is the smallest possible experiment that would answer it? Then go do that experiment tomorrow. The rest can wait.
+
+## References
+
+- Michael S. Bernstein. *CS197: Computer Science Research* — Stanford University. The **vectoring** / **velocity** framing for navigating research projects comes from this course. [cs197.stanford.edu](https://cs197.stanford.edu/) · [Bernstein's homepage](https://hci.stanford.edu/msb/).
+- Rylan Schaeffer, **Brando Miranda**, Sanmi Koyejo. *Are Emergent Abilities of Large Language Models a Mirage?* Neural Information Processing Systems (NeurIPS), 2023 — Outstanding Main Track Paper Award & Oral. [arXiv:2304.15004](https://arxiv.org/abs/2304.15004) · [OpenReview](https://openreview.net/forum?id=ITw9edRDlD). The one-line metric change (accuracy → token edit distance) that this post uses as the canonical high-velocity example.
+- W. T. Gowers. *The Two Cultures of Mathematics* and related writing on research as iterative exploration. [gowers.wordpress.com](https://gowers.wordpress.com/).
+- David Bayles & Ted Orland. *Art & Fear: Observations on the Perils (and Rewards) of Artmaking* (1993). The quantity-over-perfection ceramics-class parable.


### PR DESCRIPTION
Follow-up to #67. Adds proper attribution and a bibliography to both now-public posts.

## Changes
- **Inline citation of Michael Bernstein (Stanford) + CS197** in both posts as the source of the **vectoring** / **velocity** framing — linked to [cs197.stanford.edu](https://cs197.stanford.edu/) and [Bernstein's homepage](https://hci.stanford.edu/msb/).
- **`## References` section** at the end of each post (matching the bulleted style used in other posts), including **your bib** — the *Mirage* emergent-abilities paper (Schaeffer, **Brando Miranda**, Koyejo, NeurIPS 2023, Outstanding Paper Award & Oral) which both posts use as the worked example.
- Supporting refs each post actually draws on: Gowers + *Art & Fear* (velocity); Cheng, Bernstein, Danescu-Niculescu-Mizil & Leskovec *"Anyone Can Become a Troll"* CSCW 2017 (vectoring trolling walkthrough).

Header normalizer reports no changes (headers still canonical).

https://claude.ai/code/session_011k7wNy3UFXy3FYSizSWBsm

---
_Generated by [Claude Code](https://claude.ai/code/session_011k7wNy3UFXy3FYSizSWBsm)_